### PR TITLE
Updating packages and babel to current versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["es2015", { "modules": false }],
+    ["env", { "modules": false }],
     "react"
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -9,21 +9,22 @@
     "serve": "webpack-dev-server --hot --inline --content-base ./src"
   },
   "dependencies": {
-    "axios": "^0.15.3",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "axios": "^0.18.0",
+    "react": "^16.3.1",
+    "react-dom": "^16.3.1"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
-    "babel-loader": "^6.2.10",
+    "babel-loader": "^7.1.4",
     "babel-plugin-transform-class-properties": "^6.19.0",
-    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.16.0",
-    "css-loader": "^0.26.1",
-    "html-webpack-plugin": "^2.24.1",
-    "react-hot-loader": "3.0.0-beta.6",
-    "style-loader": "^0.13.1",
-    "webpack": "^2.1.0-beta",
+    "css-loader": "^0.28.11",
+    "html-webpack-plugin": "^3.2.0",
+    "react-hot-loader": "4.0.1",
+    "style-loader": "^0.20.3",
+    "webpack": "^4.5.0",
+    "webpack-cli": "^2.0.14",
     "webpack-dev-server": "beta"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   devtool: 'inline-source-map',
+  mode: 'development',
   entry: [
     'react-hot-loader/patch',
     resolve(__dirname, 'src', 'app.js'),


### PR DESCRIPTION
When initializing this project while going through the tutorial, I ran into issues due to mismatched packages. Webpack 4 decouples the CLI into a separate repo to alive this I updated all packages and added the new package. It also added a mode flag to webpack that needs to be set to development in order for `react-addons-perf` to work.

| Package       | Old          | New  |
| ------------- |--------------:| -----:|
|axios                           |0.15.3           | 0.18.0
|react                           |15.4.1            | 16.3.1
|react-dom                  |15.4.1            | 16.3.1
|babel-loader              |6.2.10            | 7.1.4
|babel-preset-env      |N/A                |1.6.1
|babel-preset-es2015|6.18.0            | N/A
|css-loader                  |0.26.1            | 0.28.11
|html-webpack-plugin| 2.24.1           | 3.2.0
|react-hot-loader        |3.0.0-beta.6 | 4.0.1
|style-loader                |0.13.1            | 0.20.3
|webpack                     | 2.1.0             | 4.5.0
|webpack-cli                |N/A                |2.0.14
